### PR TITLE
Fix keys failing to update (vidplay.lol status 502)

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -43,7 +43,7 @@ function getCodeVersion() {
 }
 
 async function getDeobfuscatedScript() {
-    const vidplayHost = "https://vidplay.lol"
+    const vidplayHost = "https://vidplay.online"
     const headers = {
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; rv:109.0) Gecko/20100101 Firefox/120.0",
         "Referer": vidplayHost + "/e/",


### PR DESCRIPTION
`https://vidplay.lol` is down and has been for a couple days, switched the host to `https://vidplay.online` to fix this.
From what I know they have:
- https://vidplay.lol (old)
- https://vidplay.online
- https://vidplay.site
Might be a good idea to scrape this url from vidsrc.to to determine whichever one is currently in use.